### PR TITLE
Switch getopt from char to int

### DIFF
--- a/src/ls4mkbom.cpp
+++ b/src/ls4mkbom.cpp
@@ -40,7 +40,7 @@ int main( int argc, char * argv[] ) {
   uint32_t gid = UINT_MAX;
 
   while (true) {
-    char c = getopt(argc, argv, "hu:g:");
+    int c = getopt(argc, argv, "hu:g:");
     if (c == -1) {
       break;
     }

--- a/src/lsbom.cpp
+++ b/src/lsbom.cpp
@@ -145,7 +145,7 @@ int main(int argc, char *argv[]) {
   char params[16] = "";
 
   while (true) {
-    char c = getopt(argc, argv, "hsfdlbcmxp:D::");
+    int c = getopt(argc, argv, "hsfdlbcmxp:D::");
     if (c == -1) {
       break;
     }

--- a/src/mkbom.cpp
+++ b/src/mkbom.cpp
@@ -483,7 +483,7 @@ int main( int argc, char * argv[] ) {
   bool isFileListSource = false;
 
   while (true) {
-    char c = getopt(argc, argv, "hiu:g:");
+    int c = getopt(argc, argv, "hiu:g:");
     if (c == -1) {
       break;
     }


### PR DESCRIPTION
On some architectures, char is default as signed char, which causes infinite loop here.

I have changed char to int, which fixes this. Getopt should return int anyway.

https://stackoverflow.com/questions/17070958/c-why-does-getopt-return-255-on-linux